### PR TITLE
Fix: Calls to <init> in constructors after super() are not wrapped.

### DIFF
--- a/src/main/java/janala/instrument/SnoopInstructionMethodAdapter.java
+++ b/src/main/java/janala/instrument/SnoopInstructionMethodAdapter.java
@@ -660,7 +660,7 @@ public class SnoopInstructionMethodAdapter extends MethodVisitor implements Opco
   @Override
   public void visitMethodInsn(int opcode, String owner, String name, String desc, boolean itf) {
     if (opcode == INVOKESPECIAL && name.equals("<init>")) {
-      if (isInit) {
+      if (isInit && isSuperInitCalled == false) {
         // This code is already inside an init method.
         //
         // Constructor calls to <init> method of the super class. If this is the


### PR DESCRIPTION
Constructors can call constructors of other objects, and these must be wrapped as they may throw exceptions. For example:

```java
public class Foo {
  private Bar x;
  public Foo() {
    super(); // cannot be wrapped due to uninitialized "this"
    this.x = new Bar(); // should be wrapped with try-catch block
  }
}
```

The current implementation just assumes that all calls to `<init>` within a constructor are calls to `super()` (whether explicit or implicit). However, this is not true. Therefore, this PR only skips wrapping when `isSuperCalled` is `false`.