### PR TITLE
Use configuration

### DIFF
--- a/src/main/java/janala/config/Config.java
+++ b/src/main/java/janala/config/Config.java
@@ -74,7 +74,8 @@ public class Config {
           properties.getProperty("catg.analysisClass", "janala.logger.DJVM").replace('.', '/');
       solver = properties.getProperty("catg.solverClass", "janala.solvers.YicesSolver2");
       strategy = properties.getProperty("catg.strategyClass", "janala.solvers.DFSStrategy");
-      excludeList = properties.getProperty("catg.excludeList", "").split(",");
+      excludeList = properties.getProperty("catg.excludeList",
+              "janala,gnu/trove,java/util,java/io,java/security,sun/,javax/security,sun/security,sun/reflect,com/apple/java,java/lang,java/sql,java/nio,java/net,java/text,java/beans,dk/brics,").split(",");
       includeList = properties.getProperty("catg.includeList", "catg.CATG").split(",");
       maxStringLength = Integer.parseInt(properties.getProperty("catg.maxStringLength", "30"));
       pathId = Integer.parseInt(properties.getProperty("catg.pathId", "1"));

--- a/src/main/java/janala/instrument/SnoopInstructionTransformer.java
+++ b/src/main/java/janala/instrument/SnoopInstructionTransformer.java
@@ -26,9 +26,7 @@ public class SnoopInstructionTransformer implements ClassFileTransformer {
 
   /** packages that should be exluded from the instrumentation */
   private static boolean shouldExclude(String cname) {
-    String[] exclude = {"com/sun", "sun", "java", "jdk", "com/google/monitoring",
-                        "janala", "dk/brics"};
-    for (String e : exclude) {
+    for (String e : Config.instance.excludeList) {
       if (cname.startsWith(e)) {
         return true;
       }


### PR DESCRIPTION
The property `excludeList` was not use in the `SnoopInstructionTransformer`. Users could not exclude additional packages.